### PR TITLE
Changed if conditions on tf.Tensor objects.

### DIFF
--- a/batchnorm.py
+++ b/batchnorm.py
@@ -47,7 +47,7 @@ class ConvolutionalBatchNormalizer(object):
 
   def normalize(self, x, train=True):
     """Returns a batch-normalized version of x."""
-    if train:
+    if train is not None:
       mean, variance = tf.nn.moments(x, [0, 1, 2])
       assign_mean = self.mean.assign(mean)
       assign_variance = self.variance.assign(variance)

--- a/train.py
+++ b/train.py
@@ -218,7 +218,7 @@ elif uv == 2:
 else:
     loss = (tf.split(3, 2, loss)[0] + tf.split(3, 2, loss)[1]) / 2
 
-if phase_train:
+if phase_train is not None:
     optimizer = tf.train.GradientDescentOptimizer(0.0001)
     opt = optimizer.minimize(
         loss, global_step=global_step, gate_gradients=optimizer.GATE_NONE)


### PR DESCRIPTION
Those conditions caused error:

``` python
TypeError: Using a `tf.Tensor` as a Python `bool` is not allowed. Use `if t is not None:` instead of `if t:` to test if a tensor is defined, and use the logical TensorFlow ops to test the value of a tensor.
```

On my OS X El Capitan, Python 2.7.11, Anaconda 4.0.0 and Tensorflow 0.8.0. With those fixes I was able to run a model.
