### PR TITLE
fix tensorflow.python.framework.errors.FailedPreconditionError

### DIFF
--- a/train.py
+++ b/train.py
@@ -239,7 +239,7 @@ tf.image_summary("grayscale", grayscale_rgb, max_images=1)
 saver = tf.train.Saver()
 
 # Create the graph, etc.
-init_op = tf.initialize_all_variables()
+init_op = tf.group(tf.initialize_all_variables(), tf.initialize_local_variables())
 
 # Create a session for running operations in the Graph.
 sess = tf.Session()


### PR DESCRIPTION
fixed error (TensorFlow 0.12.0, OS X El Capitan, python 2.7) :

> tensorflow.python.framework.errors.FailedPreconditionError: Attempting to use uninitialized value input_producer/limit_epochs/epochs
> 	 [[Node: input_producer/limit_epochs/CountUpTo = CountUpTo[T=DT_INT64, _class=["loc:@input_producer/limit_epochs/epochs"], limit=1000000000, _device="/job:localhost/replica:0/task:0/cpu:0"](input_producer/limit_epochs/epochs)]]
> 
> FailedPreconditionError (see above for traceback): Attempting to use uninitialized value input_producer/limit_epochs/epochs
> 	 [[Node: input_producer/limit_epochs/CountUpTo = CountUpTo[T=DT_INT64, _class=["loc:@input_producer/limit_epochs/epochs"], limit=1000000000, _device="/job:localhost/replica:0/task:0/cpu:0"](input_producer/limit_epochs/epochs)]]
> 